### PR TITLE
feat: add Light/Dark labels to theme toggle

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -42,7 +42,7 @@ export default function About() {
                 As the landscape of development shifts, I'm now focused on the mechanics of velocity by building the tooling and AI-driven infrastructure that helps engineers ship UI faster without sacrificing quality or inclusive design.
               </p>
               <p>
-                My path started at <a href="https://generalassemb.ly/" target="_blank" rel="noopener noreferrer">General Assembly<span className="sr-only"> (opens in new tab)</span></a>. I was an independent Squarespace developer, moved through a creative agency focused on social good, and led me to Mailchimp, where I lead engineering for our design system.
+                I started at <a href="https://generalassemb.ly/" target="_blank" rel="noopener noreferrer">General Assembly<span className="sr-only">(opens in new tab)</span></a>, became an independent developer with Squarepsace, then built apps for a social good creative agency. Today, I lead design system engineering at Mailchimp. 
               </p>
             </div>
 

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -68,26 +68,47 @@
 .themeToggle {
   display: flex;
   align-items: center;
-  justify-content: center;
-  width: 44px;
+  gap: 6px;
   height: 44px;
+  padding: 0 10px;
   background: none;
   border: none;
   cursor: pointer;
   color: var(--color-text);
-  border-radius: 50%;
-  transition: color 0.2s, background 0.2s;
+  border-radius: 4px;
+  transition: background 0.2s;
   flex-shrink: 0;
 }
 
 .themeToggle:hover {
-  color: var(--color-accent);
   background: var(--color-border);
 }
 
 .themeToggle svg {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.themeActive {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-accent);
+}
+
+.themeInactive {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-text-subtle);
+}
+
+.themeDivider {
+  font-size: 12px;
+  color: var(--color-border);
 }
 
 .hamburger {

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -72,7 +72,10 @@ export default function Nav() {
           aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
           onClick={toggle}
         >
-          {dark ? <SunIcon /> : <MoonIcon />}
+          {dark ? <MoonIcon /> : <SunIcon />}
+          <span className={!dark ? styles.themeActive : styles.themeInactive}>Light</span>
+          <span className={styles.themeDivider}>/</span>
+          <span className={dark ? styles.themeActive : styles.themeInactive}>Dark</span>
         </button>
 
         <button


### PR DESCRIPTION
## Summary
- Add "Light / Dark" text labels to the nav theme toggle button
- Active mode is highlighted in accent color; inactive is subtle grey
- Icon now reflects current state (sun = light mode, moon = dark mode) to match label convention
- Button shape updated from circle to rounded rect to suit the wider layout

## Test plan
- [ ] "Light" label is accented and sun icon shows in light mode
- [ ] "Dark" label is accented and moon icon shows in dark mode
- [ ] Hover background appears on the full button
- [ ] Toggle still functions correctly
- [ ] Looks correct on mobile (hamburger nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)