### PR TITLE
Remove opacity animation from fadeUp motion variant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,3 +55,4 @@ All styles use semantic CSS custom properties defined in `src/index.css`. Never 
 
 - Working branch: `claude/create-portfolio-site-7JrXV` | Main: `main`
 - After every `git push`, open a PR with `gh pr create`
+- Never include Claude Code session URLs in commit messages or PR descriptions

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -3,8 +3,8 @@ import type { Variants } from 'framer-motion'
 const ease = [0.16, 1, 0.3, 1] as const
 
 export const fadeUp: Variants = {
-  hidden:  { opacity: 0, y: 24 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.9, ease } },
+  hidden:  { y: 24 },
+  visible: { y: 0, transition: { duration: 0.9, ease } },
 }
 
 export const stagger = (delay = 0): Variants => ({


### PR DESCRIPTION
## Summary
- Remove `opacity` from the `fadeUp` motion variant — text now animates position only (`y: 24 → 0`), never passing through a low-opacity state

## Why
The axe accessibility scanner (running via Playwright) captured the `<p>Atlanta, GA</p>` element mid-animation when Framer Motion had set opacity to ~0.4. At that opacity, the text color (`#6B6B6B`) blends with the background (`#F9F8F6`) to produce an effective foreground of `#c0bfbe` — a 1.72:1 contrast ratio, far below the WCAG AA requirement of 4.5:1.

Mathematically, text needs ≥97% opacity to pass 4.5:1 against this background, so any 0→1 opacity transition will fail contrast for nearly its entire duration. The only robust fix is to not animate opacity at all.

## Test plan
- [ ] Verify the accessibility CI check passes on this PR
- [ ] Confirm `<p>Atlanta, GA</p>` no longer flagged by axe for color contrast

Fixes #20