### PR TITLE
fix: remove opacity from Nav animation to resolve color contrast violations

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -50,8 +50,8 @@ export default function Nav() {
     <motion.nav
       className={`${styles.nav} ${(scrolled || mobileOpen) ? styles.scrolled : ''}`}
       aria-label="Main navigation"
-      initial={{ opacity: 0, y: -12 }}
-      animate={{ opacity: 1, y: 0 }}
+      initial={{ y: -12 }}
+      animate={{ y: 0 }}
       transition={{ duration: 0.5, ease: [0.16, 1, 0.3, 1] }}
     >
       <div className={styles.inner}>


### PR DESCRIPTION
## Summary
- Remove `opacity` from the Nav entrance animation — the nav now only animates `y` (slide down from -12px), never passing through a low-opacity state

## Why
The axe scanner was repeatedly flagging the `Dark` theme toggle label across multiple runs (issues #19, #23, #24, #28, #30). The Nav used `initial={{ opacity: 0, y: -12 }}`, and at ~93% opacity during the transition, the `--color-text-subtle` text (`#6B6B6B`) blended with the background (`#F9F8F6`) to produce effective colors around `#737373`–`#767676` — just barely below the WCAG AA 4.5:1 threshold.

Issue #26 (`Atlanta, GA` contrast failure at 1.62:1) is also resolved: it's the same opacity-animation root cause, already fixed in the merged PR #29 which removed opacity from the `fadeUp` variant.

## Test plan
- [ ] Verify the accessibility CI check passes
- [ ] Confirm `Dark` label and `Atlanta, GA` are no longer flagged by axe for color contrast

Closes #19, #23, #24, #26, #28, #30

---
_Generated by [Claude Code](https://claude.ai/code/session_017rbYTZGzVNvAH5tzDjVWxc)_