### PR TITLE
fix: add installCommand to vercel.json to resolve vite not found build error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "framework": "vite",
+  "installCommand": "npm install",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [


### PR DESCRIPTION
## Summary
- Add `"installCommand": "npm install"` to `vercel.json`

## Why
Vercel sets `NODE_ENV=production` during builds, which causes npm to skip `devDependencies`. Since `vite` lives in `devDependencies`, the build fails with `sh: line 1: vite: command not found`.

Explicitly setting `installCommand` to `npm install` overrides this behaviour and ensures all dependencies — including build tools — are installed before the build runs.

## Test plan
- [ ] Vercel preview build succeeds on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_017rbYTZGzVNvAH5tzDjVWxc)_