### PR TITLE
fix: skip Vercel builds on the gh-cache branch

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "installCommand": "npm install",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = 'gh-cache' ]",
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
   ]


### PR DESCRIPTION
## Summary
- Add `ignoreCommand` to `vercel.json` so Vercel skips builds on the `gh-cache` branch

## Why
The accessibility scanner GitHub Action saves cached result JSON files by pushing commits to the `gh-cache` branch. Vercel was treating every push to that branch as a deployment trigger, causing `vite: command not found` build failures (since `gh-cache` commits reference source code that predated the `installCommand` fix, or Vercel was using stale cached build artifacts).

The `gh-cache` branch is purely a CI caching mechanism — it should never be deployed. The `ignoreCommand` exits with code 0 when `VERCEL_GIT_COMMIT_REF` equals `gh-cache`, which is Vercel's signal to skip the build entirely.

## Test plan
- [ ] Vercel preview builds succeed on normal branches
- [ ] No Vercel build is triggered when the accessibility scanner next pushes to `gh-cache`

---
_Generated by [Claude Code](https://claude.ai/code/session_017rbYTZGzVNvAH5tzDjVWxc)_