### PR TITLE
feat: project detail pages, section reorder, TOC sidebar, and a11y fixes

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,8 +1,17 @@
+export interface RelatedWork {
+  name: string
+  tags: string[]
+  image?: { src: string; alt: string }
+  approach: { heading: string; body: string }[]
+  outcome: string[]
+}
+
 export interface ProjectDetail {
   role: string
   image?: { src: string; alt: string }
   approach: { heading: string; body: string }[]
   outcome: string[]
+  related?: RelatedWork[]
 }
 
 export interface Project {
@@ -32,8 +41,8 @@ export const projects: Project[] = [
   {
     name: 'Mailchimp Design System',
     description:
-      "Engineering Tech Lead. Component library and design token architecture built for accessibility, scale, and cross-team consistency across Mailchimp's product suite.",
-    tags: ['React', 'TypeScript', 'Storybook', 'CSS Variables', 'Vite', 'a11y'],
+      "Engineering Tech Lead. Led design system engineering at Intuit Mailchimp, including the component library and token architecture, CSS variable dark mode, and the 2025 product redesign.",
+    tags: ['React', 'TypeScript', 'CSS Variables', 'Design Tokens', 'Storybook', 'a11y', 'Technical Leadership'],
     url: null,
     slug: 'mailchimp-design-system',
     detail: {
@@ -58,40 +67,59 @@ export const projects: Project[] = [
         'Multiple teams shipped accessible UI without additional accessibility review cycles.',
         'Cross-functional contribution model brought engineers from 4+ teams with zero breaking changes.',
       ],
-    },
-  },
-  {
-    name: 'Intuit Mailchimp App Redesign',
-    description:
-      'Staff Software Engineer. Led the technical implementation of the Mailchimp app redesign, directing 8 engineers across 21 releases to deliver 686 development tickets, 221 critical bug fixes, and 50+ new core UI components.',
-    tags: ['React', 'TypeScript', 'UI Components', 'CSS Theming', 'Technical Leadership'],
-    url: null,
-    slug: 'mailchimp-app-redesign',
-    detail: {
-      role: 'Led the technical implementation of the Intuit Mailchimp app redesign with a team of 8 engineers, starting February 2025.',
-      image: {
-        src: '/mailchimp-app-redesign.png',
-        alt: 'Mailchimp app redesign showing the new navigation and home screen',
-      },
-      approach: [
+      related: [
         {
-          heading: 'Ecosystem integration',
-          body: "Led the strategic alignment of Mailchimp's UI architecture with the Intuit global ecosystem. Standardized iconography and design tokens for cross-platform consistency and shared library interoperability across Intuit products.",
+          name: 'Intuit Mailchimp App Redesign',
+          tags: ['React', 'TypeScript', 'UI Components', 'CSS Theming', 'Technical Leadership'],
+          image: {
+            src: '/mailchimp-app-redesign.png',
+            alt: 'Mailchimp app redesign showing the new navigation and home screen',
+          },
+          approach: [
+            {
+              heading: 'Ecosystem integration',
+              body: "Led the strategic alignment of Mailchimp's UI architecture with the Intuit global ecosystem. Standardized iconography and design tokens for cross-platform consistency and shared library interoperability across Intuit products.",
+            },
+            {
+              heading: 'Release engineering',
+              body: 'Directed a team of 8 engineers across 21 releases and managed a pipeline of 686 development tickets. Structured triage kept the release cadence on schedule.',
+            },
+            {
+              heading: 'Component delivery',
+              body: 'Directed the design and delivery of 50+ new core UI components as part of the product redesign. Shipped alongside 221 critical bug fixes across all 21 releases.',
+            },
+          ],
+          outcome: [
+            '686 development tickets delivered across 21 releases.',
+            '221 critical bug fixes shipped across the rollout.',
+            '50+ new core UI components delivered as part of the product redesign.',
+            'Mailchimp UI architecture standardized with the Intuit global design system tooling.',
+          ],
         },
         {
-          heading: 'Release engineering',
-          body: 'Directed a team of 8 engineers across 21 releases and managed a pipeline of 686 development tickets. Structured triage kept the release cadence on schedule.',
+          name: 'Dark Mode',
+          tags: ['CSS Variables', 'Design Tokens', 'CSS Theming'],
+          approach: [
+            {
+              heading: 'Token package integration',
+              body: "Pulled in the Intuit Design System token package and mapped its global primitive tokens to Mailchimp's semantic CSS variable layer. This gave both light and dark values a single source of truth tied to the Intuit ecosystem.",
+            },
+            {
+              heading: 'CSS variable architecture',
+              body: 'Implemented runtime theme switching using CSS custom properties scoped to a data attribute on the root element. Component code required no changes to support dark mode. Theming is handled entirely at the token layer.',
+            },
+            {
+              heading: 'Surface migration',
+              body: "Audited Mailchimp's product surfaces for raw color values and migrated them to the semantic token layer as part of the rollout. This brought each surface into compliance with the new theming architecture.",
+            },
+          ],
+          outcome: [
+            'Dark mode shipped across Mailchimp product surfaces.',
+            'Zero component code changes required. Theme switching is handled at the CSS variable layer.',
+            "Mailchimp's token architecture aligned with the Intuit Design System token package.",
+            'Raw color values replaced with semantic tokens across migrated product surfaces.',
+          ],
         },
-        {
-          heading: 'Component delivery',
-          body: 'Directed the design and delivery of 50+ new core UI components as part of the product redesign. Shipped alongside 221 critical bug fixes across all 21 releases.',
-        },
-      ],
-      outcome: [
-        '686 development tickets delivered across 21 releases.',
-        '221 critical bug fixes shipped across the rollout.',
-        '50+ new core UI components delivered as part of the product redesign.',
-        'Mailchimp UI architecture standardized with the Intuit global design system tooling.',
       ],
     },
   },

--- a/src/pages/ProjectDetail.module.css
+++ b/src/pages/ProjectDetail.module.css
@@ -2,9 +2,17 @@
   padding: 128px 48px;
 }
 
-.inner {
-  max-width: 800px;
+.layout {
+  max-width: 1100px;
   margin: 0 auto;
+  display: grid;
+  grid-template-columns: 1fr 180px;
+  gap: 80px;
+  align-items: start;
+}
+
+.content {
+  min-width: 0;
 }
 
 .back {
@@ -28,11 +36,6 @@
 }
 
 .header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 24px;
-  flex-wrap: wrap;
   margin-bottom: 24px;
 }
 
@@ -44,6 +47,10 @@
   color: var(--color-text);
 }
 
+.title:focus:not(:focus-visible) {
+  outline: none;
+}
+
 .tags {
   display: flex;
   flex-wrap: wrap;
@@ -51,7 +58,6 @@
   list-style: none;
   padding: 0;
   margin: 0;
-  padding-top: 10px;
 }
 
 .tag {
@@ -152,18 +158,112 @@
   color: var(--color-accent);
 }
 
+.relatedList {
+  display: flex;
+  flex-direction: column;
+}
+
+.relatedItem {
+  display: flex;
+  flex-direction: column;
+}
+
+.relatedHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.relatedName {
+  font-size: clamp(22px, 3vw, 32px);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+  color: var(--color-text);
+}
+
+.relatedRule {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: 56px 0;
+}
+
+/* ── Table of contents ── */
+
+.toc {
+  position: sticky;
+  top: 120px;
+}
+
+.tocLabel {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-text-subtle);
+  margin-bottom: 16px;
+}
+
+.tocList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tocLink {
+  display: block;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: var(--color-text-subtle);
+  text-decoration: none;
+  padding: 4px 0 4px 12px;
+  border-left: 2px solid transparent;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.tocLink:hover {
+  color: var(--color-text);
+}
+
+.tocLinkActive {
+  color: var(--color-text);
+  font-weight: 600;
+  border-left-color: var(--color-accent);
+}
+
+.tocDivider {
+  height: 1px;
+  background: var(--color-border);
+  margin: 10px 0;
+}
+
+@media (max-width: 960px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .toc {
+    display: none;
+  }
+}
+
 @media (max-width: 640px) {
   .page {
     padding: 80px 24px;
   }
 
-  .header {
-    flex-direction: column;
-    gap: 16px;
-  }
-
   .approachBlock {
     grid-template-columns: 1fr;
     gap: 8px;
+  }
+
+  .relatedHeader {
+    flex-direction: column;
+    gap: 16px;
   }
 }

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useState } from 'react'
+import { useRef, useEffect, useState, useMemo } from 'react'
 import { useParams, Link, Navigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { fadeUp, stagger } from '../lib/motion'
@@ -11,21 +11,19 @@ export default function ProjectDetail() {
   const headingRef = useRef<HTMLHeadingElement>(null)
   const [activeId, setActiveId] = useState('approach-heading')
 
+  const relatedCount = project?.detail?.related?.length ?? 0
+  const tocIds = useMemo(
+    () => [
+      'approach-heading',
+      'outcome-heading',
+      ...Array.from({ length: relatedCount }, (_, i) => `related-${i}`),
+    ],
+    [relatedCount]
+  )
+
   useEffect(() => {
     headingRef.current?.focus()
   }, [])
-
-  if (!project || !project.detail) {
-    return <Navigate to="/" replace />
-  }
-
-  const { detail } = project
-
-  const tocIds = [
-    'approach-heading',
-    'outcome-heading',
-    ...(detail.related?.map((_, i) => `related-${i}`) ?? []),
-  ]
 
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -41,7 +39,13 @@ export default function ProjectDetail() {
       if (el) observer.observe(el)
     })
     return () => observer.disconnect()
-  }, [])
+  }, [tocIds])
+
+  if (!project || !project.detail) {
+    return <Navigate to="/" replace />
+  }
+
+  const { detail } = project
 
   return (
     <article className={styles.page} aria-labelledby="project-heading">

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react'
+import { useRef, useEffect, useState } from 'react'
 import { useParams, Link, Navigate } from 'react-router-dom'
 import { motion } from 'framer-motion'
 import { fadeUp, stagger } from '../lib/motion'
@@ -9,6 +9,7 @@ export default function ProjectDetail() {
   const { slug } = useParams<{ slug: string }>()
   const project = projects.find((p) => p.slug === slug)
   const headingRef = useRef<HTMLHeadingElement>(null)
+  const [activeId, setActiveId] = useState('approach-heading')
 
   useEffect(() => {
     headingRef.current?.focus()
@@ -20,68 +21,176 @@ export default function ProjectDetail() {
 
   const { detail } = project
 
+  const tocIds = [
+    'approach-heading',
+    'outcome-heading',
+    ...(detail.related?.map((_, i) => `related-${i}`) ?? []),
+  ]
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) setActiveId(entry.target.id)
+        })
+      },
+      { rootMargin: '-20% 0px -65% 0px' }
+    )
+    tocIds.forEach((id) => {
+      const el = document.getElementById(id)
+      if (el) observer.observe(el)
+    })
+    return () => observer.disconnect()
+  }, [])
+
   return (
     <article className={styles.page} aria-labelledby="project-heading">
-      <motion.div
-        className={styles.inner}
-        variants={stagger()}
-        initial="hidden"
-        animate="visible"
-      >
-        <motion.div variants={fadeUp}>
-          <Link to="/" className={styles.back}>
-            <span aria-hidden="true">←</span> Back to projects
-          </Link>
+      <div className={styles.layout}>
+        <motion.div
+          className={styles.content}
+          variants={stagger()}
+          initial="hidden"
+          animate="visible"
+        >
+          <motion.div variants={fadeUp}>
+            <Link to="/" className={styles.back}>
+              <span aria-hidden="true">←</span> Back to projects
+            </Link>
+          </motion.div>
+
+          <motion.header variants={fadeUp} className={styles.header}>
+            <h1 ref={headingRef} tabIndex={-1} id="project-heading" className={styles.title}>{project.name}</h1>
+          </motion.header>
+
+          <motion.p variants={fadeUp} className={styles.role}>
+            {detail.role}
+          </motion.p>
+
+          {detail.image && (
+            <motion.div variants={fadeUp} className={styles.imageWrap}>
+              <img
+                src={detail.image.src}
+                alt={detail.image.alt}
+                className={styles.image}
+              />
+            </motion.div>
+          )}
+
+          <motion.hr variants={fadeUp} className={styles.rule} />
+
+          <motion.section variants={fadeUp} aria-labelledby="approach-heading">
+            <h2 id="approach-heading" className={styles.sectionLabel}>Approach</h2>
+            <div className={styles.approachGrid}>
+              {detail.approach.map((block, i) => (
+                <div key={i} className={styles.approachBlock}>
+                  <h3 className={styles.approachHeading}>{block.heading}</h3>
+                  <p className={styles.approachBody}>{block.body}</p>
+                </div>
+              ))}
+            </div>
+          </motion.section>
+
+          <motion.hr variants={fadeUp} className={styles.rule} />
+
+          <motion.section variants={fadeUp} aria-labelledby="outcome-heading">
+            <h2 id="outcome-heading" className={styles.sectionLabel}>Outcome</h2>
+            <ul className={styles.outcomeList}>
+              {detail.outcome.map((item, i) => (
+                <li key={i} className={styles.outcomeItem}>{item}</li>
+              ))}
+            </ul>
+          </motion.section>
+
+          {detail.related && detail.related.length > 0 && (
+            <>
+              <motion.hr variants={fadeUp} className={styles.rule} style={{ marginTop: 64 }} />
+
+              <motion.section variants={fadeUp} aria-labelledby="related-heading">
+                <h2 id="related-heading" className={styles.sectionLabel}>Related work</h2>
+                <div className={styles.relatedList}>
+                  {detail.related.map((item, i) => (
+                    <div key={i} className={styles.relatedItem}>
+                      <div className={styles.relatedHeader}>
+                        <h3 id={`related-${i}`} className={styles.relatedName}>{item.name}</h3>
+                        <ul className={styles.tags} aria-label="Technologies">
+                          {item.tags.map((tag) => (
+                            <li key={tag} className={styles.tag}>{tag}</li>
+                          ))}
+                        </ul>
+                      </div>
+
+                      {item.image && (
+                        <div className={styles.imageWrap}>
+                          <img src={item.image.src} alt={item.image.alt} className={styles.image} />
+                        </div>
+                      )}
+
+                      <div className={styles.approachGrid}>
+                        {item.approach.map((block, j) => (
+                          <div key={j} className={styles.approachBlock}>
+                            <h4 className={styles.approachHeading}>{block.heading}</h4>
+                            <p className={styles.approachBody}>{block.body}</p>
+                          </div>
+                        ))}
+                      </div>
+
+                      <ul className={styles.outcomeList}>
+                        {item.outcome.map((o, j) => (
+                          <li key={j} className={styles.outcomeItem}>{o}</li>
+                        ))}
+                      </ul>
+
+                      {i < detail.related!.length - 1 && (
+                        <hr className={styles.relatedRule} />
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </motion.section>
+            </>
+          )}
         </motion.div>
 
-        <motion.header variants={fadeUp} className={styles.header}>
-          <h1 ref={headingRef} tabIndex={-1} id="project-heading" className={styles.title}>{project.name}</h1>
-          <ul className={styles.tags} aria-label="Technologies">
-            {project.tags.map((tag) => (
-              <li key={tag} className={styles.tag}>{tag}</li>
-            ))}
+        <nav className={styles.toc} aria-label="On this page">
+          <p className={styles.tocLabel} aria-hidden="true">On this page</p>
+          <ul className={styles.tocList}>
+            <li>
+              <a
+                href="#approach-heading"
+                aria-current={activeId === 'approach-heading' ? true : undefined}
+                className={`${styles.tocLink} ${activeId === 'approach-heading' ? styles.tocLinkActive : ''}`}
+              >
+                Approach
+              </a>
+            </li>
+            <li>
+              <a
+                href="#outcome-heading"
+                aria-current={activeId === 'outcome-heading' ? true : undefined}
+                className={`${styles.tocLink} ${activeId === 'outcome-heading' ? styles.tocLinkActive : ''}`}
+              >
+                Outcome
+              </a>
+            </li>
+            {detail.related && detail.related.length > 0 && (
+              <>
+                <li className={styles.tocDivider} aria-hidden="true" />
+                {detail.related.map((item, i) => (
+                  <li key={i}>
+                    <a
+                      href={`#related-${i}`}
+                      aria-current={activeId === `related-${i}` ? true : undefined}
+                      className={`${styles.tocLink} ${activeId === `related-${i}` ? styles.tocLinkActive : ''}`}
+                    >
+                      {item.name}
+                    </a>
+                  </li>
+                ))}
+              </>
+            )}
           </ul>
-        </motion.header>
-
-        <motion.p variants={fadeUp} className={styles.role}>
-          {detail.role}
-        </motion.p>
-
-        {detail.image && (
-          <motion.div variants={fadeUp} className={styles.imageWrap}>
-            <img
-              src={detail.image.src}
-              alt={detail.image.alt}
-              className={styles.image}
-            />
-          </motion.div>
-        )}
-
-        <motion.hr variants={fadeUp} className={styles.rule} />
-
-        <motion.section variants={fadeUp} aria-labelledby="approach-heading">
-          <h2 id="approach-heading" className={styles.sectionLabel}>Approach</h2>
-          <div className={styles.approachGrid}>
-            {detail.approach.map((block, i) => (
-              <div key={i} className={styles.approachBlock}>
-                <h3 className={styles.approachHeading}>{block.heading}</h3>
-                <p className={styles.approachBody}>{block.body}</p>
-              </div>
-            ))}
-          </div>
-        </motion.section>
-
-        <motion.hr variants={fadeUp} className={styles.rule} />
-
-        <motion.section variants={fadeUp} aria-labelledby="outcome-heading">
-          <h2 id="outcome-heading" className={styles.sectionLabel}>Outcome</h2>
-          <ul className={styles.outcomeList}>
-            {detail.outcome.map((item, i) => (
-              <li key={i} className={styles.outcomeItem}>{item}</li>
-            ))}
-          </ul>
-        </motion.section>
-      </motion.div>
+        </nav>
+      </div>
     </article>
   )
 }


### PR DESCRIPTION
## Summary

- Add React Router with `/projects/:slug` detail pages; Mailchimp Design System card links to a case study instead of an external URL
- Consolidate App Redesign and Dark Mode into a single Mailchimp Design System detail page under a "Related work" section
- Add sticky TOC sidebar with scroll-spy (IntersectionObserver, hidden on mobile at ≤960px)
- Reorder home page sections: About → Experience → Projects → Posts → Connect; update nav labels to match (no Posts in nav)
- Add Claude Code automations: context7 MCP, `add-project` skill, `writing-reviewer` agent, lint/env hooks
- Fix 4 a11y issues found by review: focus ring suppression (`:focus:not(:focus-visible)`), TOC anchor ids on `<h3>` not wrapper `<div>`, `aria-current` on active TOC links, `aria-hidden` on decorative TOC label

## Test plan

- [ ] Navigate to `/projects/mailchimp-design-system` — page loads, h1 receives focus
- [ ] Scroll through Approach → Outcome → Related work — TOC active state updates
- [ ] Click TOC links — page scrolls to correct heading
- [ ] At ≤960px — TOC is hidden
- [ ] Back link returns to home page at `/`
- [ ] Nav links (About, Experience, Projects, Connect) scroll to correct sections from both `/` and `/projects/:slug`
- [ ] Mailchimp card on home page shows `→` arrow and links internally; external project cards show `↗` and open in new tab