### PR TITLE
Redesign theme toggle as accessible switch component

### DIFF
--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -65,47 +65,61 @@
 .themeToggle {
   display: flex;
   align-items: center;
-  gap: 6px;
-  height: 44px;
-  padding: 0 10px;
-  background: none;
-  border: none;
+  gap: 8px;
   cursor: pointer;
-  color: var(--color-text);
-  border-radius: 4px;
-  transition: background 0.2s;
   flex-shrink: 0;
-}
-
-.themeToggle:hover {
-  background: var(--color-border);
-}
-
-.themeToggle svg {
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
-}
-
-.themeActive {
-  font-size: 12px;
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: var(--color-accent);
-}
-
-.themeInactive {
-  font-size: 12px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
   color: var(--color-text-subtle);
 }
 
-.themeDivider {
-  font-size: 12px;
-  color: var(--color-border);
+.themeToggle svg {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.themeInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.themeTrack {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: var(--color-border);
+  border-radius: 11px;
+  transition: background 0.2s;
+}
+
+.themeInput:checked ~ .themeTrack {
+  background: var(--color-accent);
+}
+
+.themeInput:focus-visible ~ .themeTrack {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.themeThumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  background: var(--color-surface);
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.themeInput:checked ~ .themeTrack .themeThumb {
+  transform: translateX(18px);
 }
 
 .hamburger {

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -66,16 +66,20 @@ export default function Nav() {
           ))}
         </ul>
 
-        <button
-          className={styles.themeToggle}
-          aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
-          onClick={toggle}
-        >
-          {dark ? <MoonIcon /> : <SunIcon />}
-          <span className={!dark ? styles.themeActive : styles.themeInactive}>Light</span>
-          <span className={styles.themeDivider}>/</span>
-          <span className={dark ? styles.themeActive : styles.themeInactive}>Dark</span>
-        </button>
+        <label className={styles.themeToggle}>
+          <SunIcon />
+          <input
+            type="checkbox"
+            className={styles.themeInput}
+            checked={dark}
+            onChange={toggle}
+            aria-label={dark ? 'Switch to light mode' : 'Switch to dark mode'}
+          />
+          <span className={styles.themeTrack}>
+            <span className={styles.themeThumb} />
+          </span>
+          <MoonIcon />
+        </label>
 
         <button
           className={styles.hamburger}


### PR DESCRIPTION
Refactors the theme toggle from a text-based button to an accessible toggle switch component with improved UX and accessibility.

## Summary
Replaced the theme toggle button (which displayed "Light / Dark" text) with a visually distinct toggle switch that uses a hidden checkbox input for proper semantic HTML and accessibility.

## Key Changes
- **Component structure**: Changed from `<button>` to `<label>` wrapping a hidden `<input type="checkbox">`, sun icon, track, and moon icon
- **Visual design**: Implemented a toggle switch with:
  - 40px × 22px track with rounded corners
  - 18px circular thumb that animates 18px on toggle
  - Color transitions: border color (unchecked) → accent color (checked)
  - Sun/moon icons flanking the switch for visual context
- **Accessibility improvements**:
  - Proper `<input type="checkbox">` for semantic HTML and keyboard support
  - Hidden input using standard sr-only technique (1px dimensions, clip rect)
  - Focus-visible outline on the track (2px accent color with 2px offset)
  - Maintained `aria-label` on the input element
- **Styling refinements**:
  - Removed padding, height, and background from toggle container
  - Increased gap from 6px to 8px
  - Changed text color to `--color-text-subtle`
  - SVG icons now 16px (down from 14px)
  - Removed hover state styling in favor of focus-visible

## Implementation Details
The switch uses CSS sibling combinators (`~`) to style the track and thumb based on the checkbox's `:checked` and `:focus-visible` states, eliminating the need for JavaScript-driven styling. The thumb's position animates via `transform: translateX()` for smooth transitions.

