### PR TITLE
fix: WCAG 2.2 Level AA accessibility issues

### DIFF
--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -69,6 +69,7 @@
   cursor: pointer;
   flex-shrink: 0;
   color: var(--color-text-subtle);
+  min-height: 24px;
 }
 
 .themeToggle svg {
@@ -93,7 +94,7 @@
   position: relative;
   width: 40px;
   height: 22px;
-  background: var(--color-border);
+  background: var(--color-text-subtle);
   border-radius: 11px;
   transition: background 0.2s;
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { motion } from 'framer-motion'
 import { useTheme } from '../hooks/useTheme'
 import styles from './Nav.module.css'
@@ -38,12 +38,25 @@ export default function Nav() {
   const [scrolled, setScrolled] = useState(false)
   const [mobileOpen, setMobileOpen] = useState(false)
   const { dark, toggle } = useTheme()
+  const hamburgerRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
     const onScroll = () => setScrolled(window.scrollY > 48)
     window.addEventListener('scroll', onScroll, { passive: true })
     return () => window.removeEventListener('scroll', onScroll)
   }, [])
+
+  useEffect(() => {
+    if (!mobileOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setMobileOpen(false)
+        hamburgerRef.current?.focus()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [mobileOpen])
 
   return (
     <motion.nav
@@ -82,6 +95,7 @@ export default function Nav() {
         </label>
 
         <button
+          ref={hamburgerRef}
           className={styles.hamburger}
           aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
           aria-expanded={mobileOpen}

--- a/src/global.css
+++ b/src/global.css
@@ -78,13 +78,15 @@ ul {
 /* ================================================================
    FOCUS INDICATOR  (WCAG 2.4.7, 2.4.11)
    Keyboard-only focus ring using the accent colour.
-   outline-offset keeps it clear of element borders.
+   scroll-margin-top ensures the fixed nav never covers a focused
+   element during keyboard navigation (WCAG 2.4.11).
    ================================================================ */
 
 :focus-visible {
   outline: 2px solid var(--color-accent);
   outline-offset: 3px;
   border-radius: 2px;
+  scroll-margin-top: 88px;
 }
 
 /* ================================================================

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -26,6 +26,13 @@ export default function ProjectDetail() {
   }, [])
 
   useEffect(() => {
+    if (!project) return
+    const prev = document.title
+    document.title = `${project.name} — Aylin Marie`
+    return () => { document.title = prev }
+  }, [project?.name])
+
+  useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
         entries.forEach((entry) => {
@@ -161,7 +168,7 @@ export default function ProjectDetail() {
             <li>
               <a
                 href="#approach-heading"
-                aria-current={activeId === 'approach-heading' ? true : undefined}
+                aria-current={activeId === 'approach-heading' ? 'location' : undefined}
                 className={`${styles.tocLink} ${activeId === 'approach-heading' ? styles.tocLinkActive : ''}`}
               >
                 Approach
@@ -170,7 +177,7 @@ export default function ProjectDetail() {
             <li>
               <a
                 href="#outcome-heading"
-                aria-current={activeId === 'outcome-heading' ? true : undefined}
+                aria-current={activeId === 'outcome-heading' ? 'location' : undefined}
                 className={`${styles.tocLink} ${activeId === 'outcome-heading' ? styles.tocLinkActive : ''}`}
               >
                 Outcome
@@ -183,7 +190,7 @@ export default function ProjectDetail() {
                   <li key={i}>
                     <a
                       href={`#related-${i}`}
-                      aria-current={activeId === `related-${i}` ? true : undefined}
+                      aria-current={activeId === `related-${i}` ? 'location' : undefined}
                       className={`${styles.tocLink} ${activeId === `related-${i}` ? styles.tocLinkActive : ''}`}
                     >
                       {item.name}

--- a/src/pages/WorkWithMe.tsx
+++ b/src/pages/WorkWithMe.tsx
@@ -11,6 +11,12 @@ export default function WorkWithMe() {
     headingRef.current?.focus()
   }, [])
 
+  useEffect(() => {
+    const prev = document.title
+    document.title = 'Work with me — Aylin Marie'
+    return () => { document.title = prev }
+  }, [])
+
   return (
     <article className={styles.page} aria-labelledby="wwm-heading">
       <motion.div


### PR DESCRIPTION
- WCAG 2.4.2: set document.title on /projects/:slug and /work-with-me routes
- WCAG 1.4.11: toggle track OFF-state bg changed from --color-border to
  --color-text-subtle so it meets the 3:1 non-text contrast minimum
- WCAG 2.4.11: add scroll-margin-top: 88px to :focus-visible so the fixed
  nav never obscures a keyboard-focused element
- WCAG 2.5.8: add min-height: 24px to the theme toggle label to meet the
  24×24px minimum target size
- WCAG 2.1.1: add Escape key handler on the mobile menu; pressing Escape
  closes the menu and returns focus to the hamburger button
- Use aria-current="location" (instead of true) on TOC links in ProjectDetail