### PR TITLE
Fix react-hooks/exhaustive-deps linting error in ProjectDetail

### DIFF
--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -30,7 +30,7 @@ export default function ProjectDetail() {
     const prev = document.title
     document.title = `${project.name} — Aylin Marie`
     return () => { document.title = prev }
-  }, [project?.name])
+  }, [project])
 
   useEffect(() => {
     const observer = new IntersectionObserver(


### PR DESCRIPTION
Change useEffect dependency from project?.name to project since the
effect body references project directly for the null guard.