### PR TITLE
Promote app redesign to its own project card, repoint Knit Gauge link, simplify project detail page

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,6 +1,5 @@
 export interface RelatedWork {
   name: string
-  tags: string[]
   image?: { src: string; alt: string }
   images?: { src: string; alt: string; label: string }[]
   approach: { heading: string; body: string }[]
@@ -10,6 +9,7 @@ export interface RelatedWork {
 export interface ProjectDetail {
   role: string
   image?: { src: string; alt: string }
+  images?: { src: string; alt: string; label: string }[]
   demo?: 'token-typewriter'
   approach: { heading: string; body: string }[]
   outcome: string[]
@@ -58,44 +58,7 @@ export const projects: Project[] = [
       ],
       related: [
         {
-          name: 'Intuit Mailchimp App Redesign',
-          tags: ['React', 'TypeScript', 'UI Components', 'CSS Theming', 'Technical Leadership'],
-          images: [
-            {
-              src: '/mailchimp-email-report-mockup.png',
-              alt: 'Mailchimp email report screen before the redesign',
-              label: 'Before',
-            },
-            {
-              src: '/mailchimp-browser-mockup.png',
-              alt: 'Mailchimp home screen after the redesign',
-              label: 'After',
-            },
-          ],
-          approach: [
-            {
-              heading: 'Ecosystem integration',
-              body: "Led the strategic alignment of Mailchimp's UI architecture with the Intuit global ecosystem. Standardized iconography and design tokens for cross-platform consistency and shared library interoperability across Intuit products.",
-            },
-            {
-              heading: 'Release engineering',
-              body: 'Directed a team of 8 engineers across 21 releases and managed a pipeline of 686 development tickets. Structured triage kept the release cadence on schedule.',
-            },
-            {
-              heading: 'Component delivery',
-              body: 'Directed the design and delivery of 50+ new core UI components as part of the product redesign. Shipped alongside 221 critical bug fixes across all 21 releases.',
-            },
-          ],
-          outcome: [
-            '686 development tickets delivered across 21 releases.',
-            '221 critical bug fixes shipped across the rollout.',
-            '50+ new core UI components delivered as part of the product redesign.',
-            'Mailchimp UI architecture standardized with the Intuit global design system tooling.',
-          ],
-        },
-        {
           name: 'Dark Mode',
-          tags: ['CSS Variables', 'Design Tokens', 'CSS Theming'],
           approach: [
             {
               heading: 'Token package integration',
@@ -121,11 +84,54 @@ export const projects: Project[] = [
     },
   },
   {
+    name: 'Intuit Mailchimp App Redesign',
+    description:
+      "Engineering Tech Lead. Directed Mailchimp's 2025 product redesign, leading a team of 8 engineers across 21 releases to align Mailchimp's UI architecture with the Intuit global ecosystem.",
+    tags: ['React', 'TypeScript', 'UI Components', 'CSS Theming', 'Technical Leadership'],
+    url: null,
+    slug: 'mailchimp-app-redesign',
+    detail: {
+      role: "Engineering Tech Lead. Led the strategic alignment of Mailchimp's UI architecture with the Intuit global ecosystem as part of the 2025 product redesign.",
+      images: [
+        {
+          src: '/mailchimp-email-report-mockup.png',
+          alt: 'Mailchimp email report screen before the redesign',
+          label: 'Before',
+        },
+        {
+          src: '/mailchimp-browser-mockup.png',
+          alt: 'Mailchimp home screen after the redesign',
+          label: 'After',
+        },
+      ],
+      approach: [
+        {
+          heading: 'Ecosystem integration',
+          body: "Led the strategic alignment of Mailchimp's UI architecture with the Intuit global ecosystem. Standardized iconography and design tokens for cross-platform consistency and shared library interoperability across Intuit products.",
+        },
+        {
+          heading: 'Release engineering',
+          body: 'Directed a team of 8 engineers across 21 releases and managed a pipeline of 686 development tickets. Structured triage kept the release cadence on schedule.',
+        },
+        {
+          heading: 'Component delivery',
+          body: 'Directed the design and delivery of 50+ new core UI components as part of the product redesign. Shipped alongside 221 critical bug fixes across all 21 releases.',
+        },
+      ],
+      outcome: [
+        '686 development tickets delivered across 21 releases.',
+        '221 critical bug fixes shipped across the rollout.',
+        '50+ new core UI components delivered as part of the product redesign.',
+        'Mailchimp UI architecture standardized with the Intuit global design system tooling.',
+      ],
+    },
+  },
+  {
     name: 'Knit Gauge Converter',
     description:
       'Web app that helps knitters substitute yarns by estimating gauge adjustments and needle recommendations. Features Ravelry pattern import and AI-powered guidance via Claude.',
     tags: ['Next.js', 'React', 'Supabase', 'Claude AI'],
-    url: 'https://knit-gauge-converter.vercel.app/',
+    url: 'https://github.com/aylinmarie/knit-gauge-converter',
   },
   {
     name: 'Elegant Knit',

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -27,7 +27,7 @@ export interface Project {
 
 export const projects: Project[] = [
   {
-    name: 'Mailchimp Design System',
+    name: 'Intuit Mailchimp Design System',
     description:
       "Engineering Tech Lead. Led design system engineering at Intuit Mailchimp, including the component library and token architecture, CSS variable dark mode, and the 2025 product redesign.",
     tags: ['React', 'TypeScript', 'CSS Variables', 'Design Tokens', 'Storybook', 'a11y', 'Technical Leadership'],

--- a/src/pages/ProjectDetail.module.css
+++ b/src/pages/ProjectDetail.module.css
@@ -51,25 +51,6 @@
   outline: none;
 }
 
-.tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.tag {
-  font-size: var(--font-size-label);
-  font-weight: var(--font-weight-label);
-  letter-spacing: 0.02em;
-  color: var(--color-text);
-  border: 1px solid var(--color-border);
-  padding: 4px 12px;
-  border-radius: 2px;
-}
-
 .role {
   font-size: var(--font-size-body);
   font-weight: var(--font-weight-body);
@@ -185,6 +166,7 @@
 .relatedList {
   display: flex;
   flex-direction: column;
+  gap: 56px;
 }
 
 .relatedItem {
@@ -205,12 +187,6 @@
   letter-spacing: -0.02em;
   line-height: 1.15;
   color: var(--color-text);
-}
-
-.relatedRule {
-  border: none;
-  border-top: 1px solid var(--color-border);
-  margin: 56px 0;
 }
 
 /* ── Table of contents ── */

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -84,6 +84,17 @@ export default function ProjectDetail() {
             </motion.div>
           )}
 
+          {detail.images && (
+            <motion.div variants={fadeUp} className={styles.imageStack}>
+              {detail.images.map((img) => (
+                <div key={img.src} className={styles.imageWrap}>
+                  <p className={styles.imageLabel}>{img.label}</p>
+                  <img src={img.src} alt={img.alt} className={styles.image} />
+                </div>
+              ))}
+            </motion.div>
+          )}
+
           {detail.image && (
             <motion.div variants={fadeUp} className={styles.imageWrap}>
               <img
@@ -108,8 +119,6 @@ export default function ProjectDetail() {
             </div>
           </motion.section>
 
-          <motion.hr variants={fadeUp} className={styles.rule} />
-
           <motion.section variants={fadeUp} aria-labelledby="outcome-heading">
             <h2 id="outcome-heading" className={styles.sectionLabel}>Outcome</h2>
             <ul className={styles.outcomeList}>
@@ -120,63 +129,50 @@ export default function ProjectDetail() {
           </motion.section>
 
           {detail.related && detail.related.length > 0 && (
-            <>
-              <motion.hr variants={fadeUp} className={styles.rule} style={{ marginTop: 64 }} />
+            <motion.section variants={fadeUp} aria-labelledby="related-heading">
+              <h2 id="related-heading" className={styles.sectionLabel}>Related work</h2>
+              <div className={styles.relatedList}>
+                {detail.related.map((item, i) => (
+                  <div key={i} className={styles.relatedItem}>
+                    <div className={styles.relatedHeader}>
+                      <h3 id={`related-${i}`} className={styles.relatedName}>{item.name}</h3>
+                    </div>
 
-              <motion.section variants={fadeUp} aria-labelledby="related-heading">
-                <h2 id="related-heading" className={styles.sectionLabel}>Related work</h2>
-                <div className={styles.relatedList}>
-                  {detail.related.map((item, i) => (
-                    <div key={i} className={styles.relatedItem}>
-                      <div className={styles.relatedHeader}>
-                        <h3 id={`related-${i}`} className={styles.relatedName}>{item.name}</h3>
-                        <ul className={styles.tags} aria-label="Technologies">
-                          {item.tags.map((tag) => (
-                            <li key={tag} className={styles.tag}>{tag}</li>
-                          ))}
-                        </ul>
-                      </div>
-
-                      {item.images && (
-                        <div className={styles.imageStack}>
-                          {item.images.map((img) => (
-                            <div key={img.src} className={styles.imageWrap}>
-                              <p className={styles.imageLabel}>{img.label}</p>
-                              <img src={img.src} alt={img.alt} className={styles.image} />
-                            </div>
-                          ))}
-                        </div>
-                      )}
-
-                      {item.image && (
-                        <div className={styles.imageWrap}>
-                          <img src={item.image.src} alt={item.image.alt} className={styles.image} />
-                        </div>
-                      )}
-
-                      <div className={styles.approachGrid}>
-                        {item.approach.map((block, j) => (
-                          <div key={j} className={styles.approachBlock}>
-                            <h4 className={styles.approachHeading}>{block.heading}</h4>
-                            <p className={styles.approachBody}>{block.body}</p>
+                    {item.images && (
+                      <div className={styles.imageStack}>
+                        {item.images.map((img) => (
+                          <div key={img.src} className={styles.imageWrap}>
+                            <p className={styles.imageLabel}>{img.label}</p>
+                            <img src={img.src} alt={img.alt} className={styles.image} />
                           </div>
                         ))}
                       </div>
+                    )}
 
-                      <ul className={styles.outcomeList}>
-                        {item.outcome.map((o, j) => (
-                          <li key={j} className={styles.outcomeItem}>{o}</li>
-                        ))}
-                      </ul>
+                    {item.image && (
+                      <div className={styles.imageWrap}>
+                        <img src={item.image.src} alt={item.image.alt} className={styles.image} />
+                      </div>
+                    )}
 
-                      {i < detail.related!.length - 1 && (
-                        <hr className={styles.relatedRule} />
-                      )}
+                    <div className={styles.approachGrid}>
+                      {item.approach.map((block, j) => (
+                        <div key={j} className={styles.approachBlock}>
+                          <h4 className={styles.approachHeading}>{block.heading}</h4>
+                          <p className={styles.approachBody}>{block.body}</p>
+                        </div>
+                      ))}
                     </div>
-                  ))}
-                </div>
-              </motion.section>
-            </>
+
+                    <ul className={styles.outcomeList}>
+                      {item.outcome.map((o, j) => (
+                        <li key={j} className={styles.outcomeItem}>{o}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+            </motion.section>
           )}
         </motion.div>
 


### PR DESCRIPTION
- Knit Gauge Converter now links to the GitHub repo instead of the live app
- Extracted Intuit Mailchimp App Redesign out of the Mailchimp Design System related work into its own top-level project card with its own detail page
- Removed tag badges from related work items on project detail pages
- Removed all dividers on project detail pages except the one separating the intro from the rest of the content